### PR TITLE
Tweak setup inputs to allow for a minimum / maximum number of votes

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,8 +146,13 @@
 				</div>
 				
 				<div class="w-100">
-					<p class="lead text-center">
+					<p id="voting-remaining-text-absolute" class="lead text-center" hidden>
 						Nombre de vote restant : <span id="voting-remaining-count" class="font-weight-bold"></span>
+					</p>
+					<p id="voting-remaining-text-multiple" class="lead text-center" hidden>
+						Nombre de vote minimum restant : <span id="voting-remaining-count-min" class="font-weight-bold"></span>
+						<br>
+						Nombre de vote maximum restant : <span id="voting-remaining-count-max" class="font-weight-bold"></span>
 					</p>
 					<button type="button" id="voting-submit-button" class="btn btn-success btn-lg btn-block" disabled>Enregistrer mes votes</button>
 				</div>

--- a/index.html
+++ b/index.html
@@ -96,8 +96,19 @@
 				</div>
 				<div class="form-group row">
 					<label class="col-sm-3 col-form-label" for="number-of-votes">Nombre de votes par voteur</label>
-					<div class="col-sm-9">
-						<input type="number" class="form-control is-invalid is-popable" id="number-of-votes" min="1" aria-describedby="numberOfVotes" name="numberOfVotes" data-placement="top" required>
+					<div class="col-sm-9 row pr-0">
+						<div class="col-4 col-md-3 col-lg-2 py-0 col-form-label">
+							<label class="col-form-label" for="number-of-votes-minimum">Minimum :</label>
+						</div>
+						<div class="col-8 col-md-3 col-lg-4 pr-0">
+							<input type="number" class="form-control is-invalid is-popable" id="number-of-votes-minimum" min="0" name="numberOfVotesMin" data-placement="top" required>
+						</div>
+						<div class="col-4 col-md-3 col-lg-2 py-0 col-form-label mt-3 mt-md-0">
+							<label class="col-form-label" for="number-of-votes-maximum">Maximum :</label>
+						</div>
+						<div class="col-8 col-md-3 col-lg-4 mt-3 mt-md-0 pr-0">
+							<input type="number" class="form-control is-invalid is-popable" id="number-of-votes-maximum" name="numberOfVotesMax" data-placement="top" required>
+						</div>
 					</div>
 				</div>
 				<div class="form-group row">

--- a/js/voting.js
+++ b/js/voting.js
@@ -79,6 +79,10 @@ function setup_voting_session(data) {
 	
 	const submitVotesButton = document.getElementById("voting-submit-button");
 	
+	if(minNumberOfVotesLeft == 0){
+		submitVotesButton.disabled = false;
+	}
+	
 	const votingButtons = document.querySelectorAll("button[id^=vote-candidate-]");
 	
 	votingButtons.forEach(button => {
@@ -101,7 +105,7 @@ function setup_voting_session(data) {
 				
 			}
 			
-			if(minNumberOfVotesLeft == 0){
+			if(minNumberOfVotesLeft <= 0){
 				submitVotesButton.disabled = false;
 			}
 			
@@ -142,7 +146,7 @@ function setup_voting_session(data) {
 			
 			disabledNonVotedCandidatesButtons.forEach(button => button.disabled = false);
 			
-			if(minNumberOfVotesLeft != 0){
+			if(minNumberOfVotesLeft > 0){
 				submitVotesButton.disabled = true;
 			}
 			

--- a/js/voting.js
+++ b/js/voting.js
@@ -45,11 +45,37 @@ function setup_voting_session(data) {
 	
 	$(cardsContainer).append(`<div class="row d-flex justify-content-center px-2 px-md-0">${cardsHtml}</div>`);
 	
+	let minNumberOfVotesLeft = data.numberOfVotePerVoterMin;
+	let maxNumberOfVotesLeft = data.numberOfVotePerVoterMax;
+	
+	if (minNumberOfVotesLeft == undefined && maxNumberOfVotesLeft == undefined) {
+		
+		const backwardCompatibleNumber = data.numberOfVotePerVoter;
+		
+		minNumberOfVotesLeft = backwardCompatibleNumber;
+		maxNumberOfVotesLeft = backwardCompatibleNumber;
+		
+	}
+	
 	const voteRemainingCounter = document.getElementById("voting-remaining-count");
+	const voteRemainingCounterMin = document.getElementById("voting-remaining-count-min");
+	const voteRemainingCounterMax = document.getElementById("voting-remaining-count-max");
 	
-	let numberOfVotesLeft = data.numberOfVotePerVoter;
-	
-	voteRemainingCounter.textContent = numberOfVotesLeft;
+	if (minNumberOfVotesLeft == maxNumberOfVotesLeft) {
+		
+		voteRemainingCounter.textContent = minNumberOfVotesLeft;
+		
+		document.getElementById("voting-remaining-text-absolute").hidden = false;
+		
+	}
+	else {
+		
+		voteRemainingCounterMin.textContent = minNumberOfVotesLeft;
+		voteRemainingCounterMax.textContent = maxNumberOfVotesLeft;
+		
+		document.getElementById("voting-remaining-text-multiple").hidden = false;
+		
+	}
 	
 	const submitVotesButton = document.getElementById("voting-submit-button");
 	
@@ -64,15 +90,26 @@ function setup_voting_session(data) {
 			button.hidden = true;
 			document.getElementById(`unvote-candidate-${button.dataset.voternumber}`).hidden = false;
 			
-			voteRemainingCounter.textContent = --numberOfVotesLeft;
+			if (minNumberOfVotesLeft == maxNumberOfVotesLeft) {
+				voteRemainingCounter.textContent = --minNumberOfVotesLeft;
+				--maxNumberOfVotesLeft;
+			}
+			else {
+				
+				voteRemainingCounterMin.textContent = --minNumberOfVotesLeft >= 0 ? minNumberOfVotesLeft : 0;
+				voteRemainingCounterMax.textContent = --maxNumberOfVotesLeft;
+				
+			}
 			
-			if(numberOfVotesLeft == 0){
+			if(minNumberOfVotesLeft == 0){
+				submitVotesButton.disabled = false;
+			}
+			
+			if (maxNumberOfVotesLeft == 0) {
 				
 				const nonVotedCandidatesButtons = document.querySelectorAll("button[id^=vote-candidate-]:not([hidden])");
 				
 				nonVotedCandidatesButtons.forEach(button => button.disabled = true);
-				
-				submitVotesButton.disabled = false;
 				
 			}
 			
@@ -90,13 +127,24 @@ function setup_voting_session(data) {
 			button.hidden = true;
 			document.getElementById(`vote-candidate-${button.dataset.voternumber}`).hidden = false;
 			
-			voteRemainingCounter.textContent = ++numberOfVotesLeft;
+			if (minNumberOfVotesLeft == maxNumberOfVotesLeft) {
+				voteRemainingCounter.textContent = ++minNumberOfVotesLeft;
+				++maxNumberOfVotesLeft;
+			}
+			else {
+				
+				voteRemainingCounterMin.textContent = ++minNumberOfVotesLeft >= 0 ? minNumberOfVotesLeft : 0;
+				voteRemainingCounterMax.textContent = ++maxNumberOfVotesLeft;
+				
+			}
 			
 			const disabledNonVotedCandidatesButtons = document.querySelectorAll("button[id^=vote-candidate-][disabled]");
 			
 			disabledNonVotedCandidatesButtons.forEach(button => button.disabled = false);
 			
-			submitVotesButton.disabled = true;
+			if(minNumberOfVotesLeft != 0){
+				submitVotesButton.disabled = true;
+			}
 			
 		});
 	});


### PR DESCRIPTION
This PR allows anyone to enter a minimum and a maximum number of votes that each voter will get, which allows for a dynamic range in number of votes.

The minimum and maximum can be the same to make the number of votes absolute.

This also allows anyone to set the minimum number of votes to 0, allowing the voters to skip their vote, if that's what is desired.

Closes #45