### PR TITLE
Add password input to setup page to define password behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -142,6 +142,7 @@ table.table-border {
     position: relative;
     margin: 0;
     padding: 1.1rem;
+    height: calc(1.5em + .75rem + 2px);
 }
 
 .boot-checkbox + label:active,
@@ -165,6 +166,10 @@ table.table-border {
     height: 100%;
     text-align: center;
     font-weight: bold;
+}
+
+.checkbox-eye.boot-checkbox:checked + label:after {
+    content: '\1F441';
 }
 
 /* Fix bootstrap border utilities */

--- a/index.html
+++ b/index.html
@@ -96,6 +96,16 @@
 					</div>
 				</div>
 				<div class="form-group row">
+					<label class="col-12 col-sm-3 col-md-5 col-lg-4 col-form-label" for="db-psw">Mot de passe de la base de données</label>
+					<div class="col-10 col-sm-8 col-md-6 col-lg-7">
+						<input type="text" class="form-control" id="db-psw" aria-describedby="dbPsw" name="dbPsw" data-placement="top" autocomplete="off" spellcheck="false" placeholder="(optionnel)">
+					</div>
+					<div class="d-flex col-2 col-sm-1 justify-content-end">
+						<input type="checkbox" id="password-visible" name="passwordVisible" class="boot-checkbox checkbox-eye" checked>
+						<label for="password-visible"></label>
+					</div>
+				</div>
+				<div class="form-group row">
 					<label class="col-sm-3 col-md-5 col-lg-4 col-form-label" for="number-of-voters">Nombre de voteurs</label>
 					<div class="col-sm-9 col-md-7 col-lg-8">
 						<input type="number" class="form-control is-invalid is-popable" id="number-of-voters" min="1" aria-describedby="numberOfVoters" name="numberOfVoters" data-placement="top" required>

--- a/js/index.js
+++ b/js/index.js
@@ -152,7 +152,8 @@ function route_data(data) {
 	if (data.hasSkipped || data.numberOfVoted == data.numberOfVoters) {
 		
 		isDownloadDisabled = true;
-		switch_view("pre-results-page", () => setup_pre_results_page(data));
+		
+		setup_results(data);
 		
 	}
 	else {

--- a/js/results.js
+++ b/js/results.js
@@ -1,4 +1,18 @@
+function setup_results(data) {
+	
+	if (data.dbPsw || data.dbPsw == undefined) {
+		switch_view("pre-results-page", () => setup_pre_results_page(data));
+	}
+	else {
+		switch_view("results-page", () => setup_results_page(data));
+	}
+	
+}
+
 function setup_pre_results_page(data) {
+	
+	// Default password if not set is "VL" for "Vieux-Loups"
+	let passwordToCheck = data.dbPsw || "VL";
 	
 	const preResultsSubmitButton = document.getElementById("pre-results-submit-button");
 	
@@ -9,8 +23,7 @@ function setup_pre_results_page(data) {
 		
 		const password = passwordInput.value;
 		
-		// Password is "VL" for "Vieux-Loups"
-		if (password == "VL") {
+		if (password == passwordToCheck) {
 			
 			switch_view("results-page", () => setup_results_page(data));
 			

--- a/js/setup.js
+++ b/js/setup.js
@@ -3,6 +3,11 @@ let textFieldHadFocus = undefined;
 
 function setup_setup() {
 	
+	const pswVisibilityToggler = document.getElementById("password-visible");
+	const pswField = document.getElementById("db-psw");
+	
+	pswVisibilityToggler.addEventListener("click", () => pswField.type = pswField.type == "password" ? "text" : "password");
+	
 	const candidateAddButton = document.getElementById("candidate-add");
 	const candidateRemoveButton = document.getElementById("candidate-remove");
 	const candidateContainer = document.getElementById("setup-candidates");

--- a/js/setup.js
+++ b/js/setup.js
@@ -96,6 +96,7 @@ function setup_setup() {
 		
 		let data = {
 			dbName: formData.get("dbName"),
+			dbPsw: formData.get("dbPsw"),
 			numberOfVoters: parseInt(formData.get("numberOfVoters")),
 			numberOfVotePerVoterMin: parseInt(formData.get("numberOfVotesMin")),
 			numberOfVotePerVoterMax: parseInt(formData.get("numberOfVotesMax")),

--- a/js/voting.js
+++ b/js/voting.js
@@ -367,7 +367,7 @@ function setup_voting_session(data) {
 		
 		document.getElementById("voting-toasts-container").classList.add("i-am-away");
 		
-		switch_view("pre-results-page", () => setup_pre_results_page(data));
+		setup_results(data);
 		document.body.onkeyup = onKeyUpEventBefore;
 		
 	}


### PR DESCRIPTION
If the (optionnal) password is empty, no password will be requested and as soon as there is no voter remaining, the results will be shown.

For backward compatibility reasons, if the password is not present (like, the key, not the actual data value) in the database, the previous "`VL`" will be asked.

The password is therefore stored in the database.

There is also a toggle for visibility of the password. There is no need to set it first, but the toggle might come in handy in case the device is passed around.

NOTE : The password is not encrypted, it is stored in plain text. This password is not supposed to be secure, it's just a small fence to open on the other side to prevent those who don't know the password to not see the results right away.

Closes #32